### PR TITLE
Feature/add before hook implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     sorbet (0.5.10830)
       sorbet-static (= 0.5.10830)
     sorbet-runtime (0.5.10830)
+    sorbet-static (0.5.10830-universal-darwin-21)
     sorbet-static (0.5.10830-universal-darwin-22)
     sorbet-static (0.5.10830-x86_64-linux)
     sorbet-static-and-runtime (0.5.10830)
@@ -91,6 +92,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 

--- a/lib/open_feature/client.rb
+++ b/lib/open_feature/client.rb
@@ -247,7 +247,8 @@ module OpenFeature
     def build_context_with_before_hooks(flag_key:, default_value:, invocation_context:, options:, flag_type:)
       evaluation_context = build_context(invocation_context) || OpenFeature::EvaluationContext.new
       hook_context = HookContext.new(flag_key: flag_key, default_value: default_value,
-                                     evaluation_context: evaluation_context, flag_type: flag_type)
+                                     evaluation_context: evaluation_context, flag_type: flag_type,
+                                     client_metadata: client_metadata, provider_metadata: provider.metadata)
       OpenFeature::Hook::BeforeHook.call(hooks: sequence_before_hooks(options), context: hook_context,
                                          hints: {})
     end

--- a/lib/open_feature/client.rb
+++ b/lib/open_feature/client.rb
@@ -43,10 +43,12 @@ module OpenFeature
         options: T.nilable(EvaluationOptions)
       ).returns(T::Boolean)
     end
-    def fetch_boolean_value(flag_key:, default_value:, context: nil, options: nil) # rubocop:disable Lint/UnusedMethodArgument
-      provider
-        .resolve_boolean_value(flag_key: flag_key, default_value: default_value, context: build_context(context))
-        .value
+    def fetch_boolean_value(flag_key:, default_value:, context: nil, options: nil)
+      evaluated_context = build_context_with_before_hooks(flag_key: flag_key, default_value: default_value,
+                                                          invocation_context: context, options: options,
+                                                          flag_type: "Boolean")
+      provider.resolve_boolean_value(flag_key: flag_key, default_value: default_value, context: evaluated_context)
+              .value
     rescue StandardError
       default_value
     end
@@ -79,9 +81,12 @@ module OpenFeature
         options: T.nilable(EvaluationOptions)
       ).returns(String)
     end
-    def fetch_string_value(flag_key:, default_value:, context: nil, options: nil) # rubocop:disable Lint/UnusedMethodArgument
+    def fetch_string_value(flag_key:, default_value:, context: nil, options: nil)
+      evaluated_context = build_context_with_before_hooks(flag_key: flag_key, default_value: default_value,
+                                                          invocation_context: context, options: options,
+                                                          flag_type: "String")
       provider
-        .resolve_string_value(flag_key: flag_key, default_value: default_value, context: build_context(context))
+        .resolve_string_value(flag_key: flag_key, default_value: default_value, context: evaluated_context)
         .value
     rescue StandardError
       default_value
@@ -115,9 +120,12 @@ module OpenFeature
         options: T.nilable(EvaluationOptions)
       ).returns(Numeric)
     end
-    def fetch_number_value(flag_key:, default_value:, context: nil, options: nil) # rubocop:disable Lint/UnusedMethodArgument
+    def fetch_number_value(flag_key:, default_value:, context: nil, options: nil)
+      evaluated_context = build_context_with_before_hooks(flag_key: flag_key, default_value: default_value,
+                                                          invocation_context: context, options: options,
+                                                          flag_type: "Number")
       provider
-        .resolve_number_value(flag_key: flag_key, default_value: default_value, context: build_context(context))
+        .resolve_number_value(flag_key: flag_key, default_value: default_value, context: evaluated_context)
         .value
     rescue StandardError
       default_value
@@ -151,9 +159,12 @@ module OpenFeature
         options: T.nilable(EvaluationOptions)
       ).returns(Integer)
     end
-    def fetch_integer_value(flag_key:, default_value:, context: nil, options: nil) # rubocop:disable Lint/UnusedMethodArgument
+    def fetch_integer_value(flag_key:, default_value:, context: nil, options: nil)
+      evaluated_context = build_context_with_before_hooks(flag_key: flag_key, default_value: default_value,
+                                                          invocation_context: context, options: options,
+                                                          flag_type: "Integer")
       provider
-        .resolve_number_value(flag_key: flag_key, default_value: default_value, context: build_context(context))
+        .resolve_number_value(flag_key: flag_key, default_value: default_value, context: evaluated_context)
         .value
         .to_i
     rescue StandardError
@@ -168,9 +179,12 @@ module OpenFeature
         options: T.nilable(EvaluationOptions)
       ).returns(Float)
     end
-    def fetch_float_value(flag_key:, default_value:, context: nil, options: nil) # rubocop:disable Lint/UnusedMethodArgument
+    def fetch_float_value(flag_key:, default_value:, context: nil, options: nil)
+      evaluated_context = build_context_with_before_hooks(flag_key: flag_key, default_value: default_value,
+                                                          invocation_context: context, options: options,
+                                                          flag_type: "Float")
       provider
-        .resolve_number_value(flag_key: flag_key, default_value: default_value, context: build_context(context))
+        .resolve_number_value(flag_key: flag_key, default_value: default_value, context: evaluated_context)
         .value
         .to_f
     rescue StandardError
@@ -185,9 +199,12 @@ module OpenFeature
         options: T.nilable(EvaluationOptions)
       ).returns(Structure)
     end
-    def fetch_structure_value(flag_key:, default_value:, context: nil, options: nil) # rubocop:disable Lint/UnusedMethodArgument
+    def fetch_structure_value(flag_key:, default_value:, context: nil, options: nil)
+      evaluated_context = build_context_with_before_hooks(flag_key: flag_key, default_value: default_value,
+                                                          invocation_context: context, options: options,
+                                                          flag_type: "Structure")
       provider
-        .resolve_structure_value(flag_key: flag_key, default_value: default_value, context: build_context(context))
+        .resolve_structure_value(flag_key: flag_key, default_value: default_value, context: evaluated_context)
         .value
     rescue StandardError
       default_value
@@ -217,6 +234,28 @@ module OpenFeature
 
     sig { returns(Provider) }
     attr_reader :provider
+
+    sig do
+      type_parameters(:U).params(
+        flag_key: String,
+        default_value: T.type_parameter(:U),
+        invocation_context: T.nilable(EvaluationContext),
+        options: T.nilable(EvaluationOptions),
+        flag_type: String
+      ).returns(EvaluationContext)
+    end
+    def build_context_with_before_hooks(flag_key:, default_value:, invocation_context:, options:, flag_type:)
+      evaluation_context = build_context(invocation_context) || OpenFeature::EvaluationContext.new
+      hook_context = HookContext.new(flag_key: flag_key, default_value: default_value,
+                                     evaluation_context: evaluation_context, flag_type: flag_type)
+      OpenFeature::Hook::BeforeHook.call(hooks: sequence_before_hooks(options), context: hook_context,
+                                         hints: {})
+    end
+
+    sig { params(options: T.nilable(EvaluationOptions)).returns(T::Array[Hook]) }
+    def sequence_before_hooks(options)
+      OpenFeature.configuration.hooks + hooks + (options ? options.hooks : [])
+    end
 
     sig { params(invocation_context: T.nilable(EvaluationContext)).returns(T.nilable(EvaluationContext)) }
     def build_context(invocation_context)

--- a/lib/open_feature/client_metadata.rb
+++ b/lib/open_feature/client_metadata.rb
@@ -4,6 +4,7 @@
 module OpenFeature
   # Defines information about a Client.
   class ClientMetadata < T::Struct
+    include T::Struct::ActsAsComparable
     const :name, T.nilable(String)
   end
 end

--- a/lib/open_feature/evaluation_context.rb
+++ b/lib/open_feature/evaluation_context.rb
@@ -13,7 +13,7 @@ module OpenFeature
 
     FieldValueType = T.type_alias { T.any(T::Boolean, String, Numeric, DateTime, Structure) }
 
-    const :targeting_key, T.nilable(String)
+    const :targeting_key, T.nilable(String), default: nil
     const :fields, T::Hash[String, FieldValueType], default: {}
 
     sig { params(method_name: Symbol).returns(T::Boolean) }

--- a/lib/open_feature/hook.rb
+++ b/lib/open_feature/hook.rb
@@ -27,12 +27,12 @@ module OpenFeature
         extend T::Sig
 
         sig do
-          params(hooks: T::Array[OpenFeature::Hook], context: OpenFeature::HookContext[T.untyped],
+          params(hooks: Hooks, context: OpenFeature::HookContext[T.untyped],
                  hints: T::Hash[String, T.untyped]).returns(OpenFeature::EvaluationContext)
         end
         def call(hooks:, context:, hints:)
           context.evaluation_context.merge(
-            filtered_to_type(hooks).reduce(context.evaluation_context) do |evaluation_context, hook|
+            hooks.before.reduce(context.evaluation_context) do |evaluation_context, hook|
               hook.call(
                 context: context.with_new_evaluation_context(evaluation_context),
                 hints: hints
@@ -40,27 +40,7 @@ module OpenFeature
             end
           )
         end
-
-        private
-
-        # The following function is a bit boilerplatey, perhaps there's a better way?
-        sig { params(hooks: T::Array[OpenFeature::Hook]).returns(T::Array[OpenFeature::Hook::BeforeHook]) }
-        def filtered_to_type(hooks)
-          hooks
-            .flat_map do |hook|
-              case hook
-              when OpenFeature::Hook::BeforeHook
-                [T.let(hook, OpenFeature::Hook::BeforeHook)]
-              else []
-              end
-            end
-        end
       end
-    end
-
-    # Todo
-    class AfterHook
-      include Hook
     end
   end
 end

--- a/lib/open_feature/hook.rb
+++ b/lib/open_feature/hook.rb
@@ -2,5 +2,65 @@
 # frozen_string_literal: true
 
 module OpenFeature
-  class Hook < T::Struct; end
+  # See https://openfeature.dev/specification/sections/hooks
+  # We model Hooks as a simple ADT
+  module Hook
+    extend T::Sig
+    extend T::Helpers
+    interface!
+    sealed!
+
+    # See Requirement 4.3.2 - 4.3.4
+    class BeforeHook
+      include Hook
+      extend T::Sig
+      extend T::Helpers
+      include OpenFeature::Hook
+      abstract!
+      sig do
+        abstract.params(context: OpenFeature::HookContext[T.untyped],
+                        hints: T::Hash[String, T.untyped]).returns(OpenFeature::EvaluationContext)
+      end
+      def call(context:, hints:); end
+
+      class << self
+        extend T::Sig
+
+        sig do
+          params(hooks: T::Array[OpenFeature::Hook], context: OpenFeature::HookContext[T.untyped],
+                 hints: T::Hash[String, T.untyped]).returns(OpenFeature::EvaluationContext)
+        end
+        def call(hooks:, context:, hints:)
+          context.evaluation_context.merge(
+            filtered_to_type(hooks).reduce(context.evaluation_context) do |evaluation_context, hook|
+              hook.call(
+                context: context.with_new_evaluation_context(evaluation_context),
+                hints: hints
+              )
+            end
+          )
+        end
+
+        private
+
+        # The following function is a bit boilerplatey, perhaps there's a better way?
+        sig { params(hooks: T::Array[OpenFeature::Hook]).returns(T::Array[OpenFeature::Hook::BeforeHook]) }
+        def filtered_to_type(hooks)
+          hooks
+            .flat_map do |hook|
+              case hook
+              when OpenFeature::Hook::BeforeHook
+                [T.let(hook, OpenFeature::Hook::BeforeHook)]
+              else []
+              end
+            end
+        end
+      end
+    end
+
+    # Todo
+    class AfterHook
+      include Hook
+    end
+  end
 end

--- a/lib/open_feature/hook_context.rb
+++ b/lib/open_feature/hook_context.rb
@@ -16,12 +16,15 @@ module OpenFeature
     const :flag_type, String
     const :evaluation_context, EvaluationContext
     const :default_value, Value
+    const :client_metadata, ClientMetadata
+    const :provider_metadata, ProviderMetadata
 
     # Needed as opposed to .with due to https://sorbet.org/docs/tstruct#from_hash-gotchas
     sig { params(new_context: EvaluationContext).returns(HookContext[Value]) }
     def with_new_evaluation_context(new_context)
       OpenFeature::HookContext.new(flag_key: flag_key, flag_type: flag_type, default_value: default_value,
-                                   evaluation_context: new_context)
+                                   evaluation_context: new_context, client_metadata: client_metadata,
+                                   provider_metadata: provider_metadata)
     end
   end
 end

--- a/lib/open_feature/hook_context.rb
+++ b/lib/open_feature/hook_context.rb
@@ -1,0 +1,27 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OpenFeature
+  # See https://openfeature.dev/specification/sections/hooks#41-hook-context
+  # See Requirement 4.1.1, 4.1.3, 4.1.4
+  # TODO: Requirement 4.1.2
+  class HookContext < T::Struct
+    extend T::Generic
+    extend T::Sig
+
+    include T::Struct::ActsAsComparable
+
+    Value = type_member
+    const :flag_key, String
+    const :flag_type, String
+    const :evaluation_context, EvaluationContext
+    const :default_value, Value
+
+    # Needed as opposed to .with due to https://sorbet.org/docs/tstruct#from_hash-gotchas
+    sig { params(new_context: EvaluationContext).returns(HookContext[Value]) }
+    def with_new_evaluation_context(new_context)
+      OpenFeature::HookContext.new(flag_key: flag_key, flag_type: flag_type, default_value: default_value,
+                                   evaluation_context: new_context)
+    end
+  end
+end

--- a/lib/open_feature/hooks.rb
+++ b/lib/open_feature/hooks.rb
@@ -1,0 +1,22 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OpenFeature
+  # Represents full set of hooks with helper methods for filtering and sequencing each subtype
+  class Hooks < T::Struct
+    extend T::Generic
+    extend T::Sig
+    const :global, T::Array[Hook], default: []
+    const :provider, T::Array[Hook], default: []
+    const :client, T::Array[Hook], default: []
+    const :invocation, T::Array[Hook], default: []
+
+    # See Requirement 4.4.2
+    # TODO: when there is >1 subtype of hook will need to filter and not simply re-cast
+    #   ACHTUNG! T.cast is safe for now but will need to be updated after ^
+    sig { returns(T::Array[Hook::BeforeHook]) }
+    def before
+      T.cast(global + client + invocation + provider, T::Array[Hook::BeforeHook])
+    end
+  end
+end

--- a/test/open_feature/client_test.rb
+++ b/test/open_feature/client_test.rb
@@ -7,7 +7,8 @@ require_relative "../support/test_hook"
 
 class ClientTest < Minitest::Test
   def setup
-    @client = OpenFeature::Client.new(provider: TestProvider.new, name: "testing")
+    @client_provider = TestProvider.new
+    @client = OpenFeature::Client.new(provider: @client_provider, name: "testing")
     @raising_client = OpenFeature::Client.new(provider: TestProvider.new(raising: true))
     @integer_client = OpenFeature::Client.new(provider: TestProvider.new(number_value: 2))
   end
@@ -218,10 +219,7 @@ class ClientTest < Minitest::Test
 
   def test_fetch_boolean_value_invokes_before_hook
     hook = TestHook.new mock: Minitest::Mock.new
-    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
-                                                         flag_type: "Boolean",
-                                                         evaluation_context: OpenFeature::EvaluationContext.new,
-                                                         default_value: false)
+    expected_hook_context = build_test_hook_context(flag_type: "Boolean", default_value: false)
     hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
     @client.fetch_boolean_value(flag_key: "testing", default_value: false, options: OpenFeature::EvaluationOptions.new(
       hooks: [hook]
@@ -231,10 +229,7 @@ class ClientTest < Minitest::Test
 
   def test_fetch_string_value_invokes_before_hook
     hook = TestHook.new mock: Minitest::Mock.new
-    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
-                                                         flag_type: "String",
-                                                         evaluation_context: OpenFeature::EvaluationContext.new,
-                                                         default_value: "foo")
+    expected_hook_context = build_test_hook_context(flag_type: "String", default_value: "foo")
     hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
     @client.fetch_string_value(flag_key: "testing", default_value: "foo", options: OpenFeature::EvaluationOptions.new(
       hooks: [hook]
@@ -244,10 +239,7 @@ class ClientTest < Minitest::Test
 
   def test_fetch_integer_value_invokes_before_hook
     hook = TestHook.new mock: Minitest::Mock.new
-    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
-                                                         flag_type: "Integer",
-                                                         evaluation_context: OpenFeature::EvaluationContext.new,
-                                                         default_value: 43)
+    expected_hook_context = build_test_hook_context(flag_type: "Integer", default_value: 43)
     hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
     @client.fetch_integer_value(flag_key: "testing", default_value: 43, options: OpenFeature::EvaluationOptions.new(
       hooks: [hook]
@@ -257,10 +249,7 @@ class ClientTest < Minitest::Test
 
   def test_fetch_number_value_invokes_before_hook
     hook = TestHook.new mock: Minitest::Mock.new
-    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
-                                                         flag_type: "Number",
-                                                         evaluation_context: OpenFeature::EvaluationContext.new,
-                                                         default_value: 3.14)
+    expected_hook_context = build_test_hook_context(flag_type: "Number", default_value: 3.14)
     hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
     @client.fetch_number_value(flag_key: "testing", default_value: 3.14, options: OpenFeature::EvaluationOptions.new(
       hooks: [hook]
@@ -270,10 +259,7 @@ class ClientTest < Minitest::Test
 
   def test_fetch_float_value_invokes_before_hook
     hook = TestHook.new mock: Minitest::Mock.new
-    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
-                                                         flag_type: "Float",
-                                                         evaluation_context: OpenFeature::EvaluationContext.new,
-                                                         default_value: 3.14)
+    expected_hook_context = build_test_hook_context(flag_type: "Float", default_value: 3.14)
     hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
     @client.fetch_float_value(flag_key: "testing", default_value: 3.14, options: OpenFeature::EvaluationOptions.new(
       hooks: [hook]
@@ -283,15 +269,23 @@ class ClientTest < Minitest::Test
 
   def test_fetch_structure_value_invokes_before_hook
     hook = TestHook.new mock: Minitest::Mock.new
-    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
-                                                         flag_type: "Structure",
-                                                         evaluation_context: OpenFeature::EvaluationContext.new,
-                                                         default_value: { "another" => "test" })
+    expected_hook_context = build_test_hook_context(flag_type: "Structure", default_value: { "another" => "test" })
     hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
     @client.fetch_structure_value(flag_key: "testing", default_value: { "another" => "test" },
                                   options: OpenFeature::EvaluationOptions.new(
                                     hooks: [hook]
                                   ))
     hook.mock.verify
+  end
+
+  private
+
+  def build_test_hook_context(flag_type:, default_value:)
+    OpenFeature::HookContext.new(flag_key: "testing",
+                                 flag_type: flag_type,
+                                 evaluation_context: OpenFeature::EvaluationContext.new,
+                                 default_value: default_value,
+                                 client_metadata: @client.client_metadata,
+                                 provider_metadata: @client_provider.metadata)
   end
 end

--- a/test/open_feature/client_test.rb
+++ b/test/open_feature/client_test.rb
@@ -3,6 +3,7 @@
 
 require "test_helper"
 require_relative "../support/test_provider"
+require_relative "../support/test_hook"
 
 class ClientTest < Minitest::Test
   def setup
@@ -24,7 +25,7 @@ class ClientTest < Minitest::Test
       provider: TestProvider.new,
       name: "testing",
       evaluation_context: OpenFeature::EvaluationContext.new,
-      hooks: [OpenFeature::Hook.new]
+      hooks: [TestHook.new]
     )
 
     refute_nil(client.client_metadata.name)
@@ -33,8 +34,8 @@ class ClientTest < Minitest::Test
   end
 
   def test_hooks_can_be_added
-    @client.add_hooks(OpenFeature::Hook.new)
-    @client.add_hooks([OpenFeature::Hook.new, OpenFeature::Hook.new])
+    @client.add_hooks(TestHook.new)
+    @client.add_hooks([TestHook.new, TestHook.new])
 
     assert_equal(3, @client.hooks.size)
   end

--- a/test/open_feature/client_test.rb
+++ b/test/open_feature/client_test.rb
@@ -215,4 +215,83 @@ class ClientTest < Minitest::Test
 
     assert_equal(expected_details, details)
   end
+
+  def test_fetch_boolean_value_invokes_before_hook
+    hook = TestHook.new mock: Minitest::Mock.new
+    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
+                                                         flag_type: "Boolean",
+                                                         evaluation_context: OpenFeature::EvaluationContext.new,
+                                                         default_value: false)
+    hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
+    @client.fetch_boolean_value(flag_key: "testing", default_value: false, options: OpenFeature::EvaluationOptions.new(
+      hooks: [hook]
+    ))
+    hook.mock.verify
+  end
+
+  def test_fetch_string_value_invokes_before_hook
+    hook = TestHook.new mock: Minitest::Mock.new
+    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
+                                                         flag_type: "String",
+                                                         evaluation_context: OpenFeature::EvaluationContext.new,
+                                                         default_value: "foo")
+    hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
+    @client.fetch_string_value(flag_key: "testing", default_value: "foo", options: OpenFeature::EvaluationOptions.new(
+      hooks: [hook]
+    ))
+    hook.mock.verify
+  end
+
+  def test_fetch_integer_value_invokes_before_hook
+    hook = TestHook.new mock: Minitest::Mock.new
+    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
+                                                         flag_type: "Integer",
+                                                         evaluation_context: OpenFeature::EvaluationContext.new,
+                                                         default_value: 43)
+    hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
+    @client.fetch_integer_value(flag_key: "testing", default_value: 43, options: OpenFeature::EvaluationOptions.new(
+      hooks: [hook]
+    ))
+    hook.mock.verify
+  end
+
+  def test_fetch_number_value_invokes_before_hook
+    hook = TestHook.new mock: Minitest::Mock.new
+    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
+                                                         flag_type: "Number",
+                                                         evaluation_context: OpenFeature::EvaluationContext.new,
+                                                         default_value: 3.14)
+    hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
+    @client.fetch_number_value(flag_key: "testing", default_value: 3.14, options: OpenFeature::EvaluationOptions.new(
+      hooks: [hook]
+    ))
+    hook.mock.verify
+  end
+
+  def test_fetch_float_value_invokes_before_hook
+    hook = TestHook.new mock: Minitest::Mock.new
+    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
+                                                         flag_type: "Float",
+                                                         evaluation_context: OpenFeature::EvaluationContext.new,
+                                                         default_value: 3.14)
+    hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
+    @client.fetch_float_value(flag_key: "testing", default_value: 3.14, options: OpenFeature::EvaluationOptions.new(
+      hooks: [hook]
+    ))
+    hook.mock.verify
+  end
+
+  def test_fetch_structure_value_invokes_before_hook
+    hook = TestHook.new mock: Minitest::Mock.new
+    expected_hook_context = OpenFeature::HookContext.new(flag_key: "testing",
+                                                         flag_type: "Structure",
+                                                         evaluation_context: OpenFeature::EvaluationContext.new,
+                                                         default_value: { "another" => "test" })
+    hook.mock.expect(:call, expected_hook_context, [[expected_hook_context, {}]])
+    @client.fetch_structure_value(flag_key: "testing", default_value: { "another" => "test" },
+                                  options: OpenFeature::EvaluationOptions.new(
+                                    hooks: [hook]
+                                  ))
+    hook.mock.verify
+  end
 end

--- a/test/open_feature/configuration_test.rb
+++ b/test/open_feature/configuration_test.rb
@@ -3,6 +3,7 @@
 
 require "test_helper"
 require_relative "../support/test_provider"
+require_relative "../support/test_hook"
 
 class ConfigurationTest < Minitest::Test
   def teardown
@@ -18,7 +19,7 @@ class ConfigurationTest < Minitest::Test
   # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
   def test_configuration_can_be_reset
     OpenFeature::Configuration.instance.provider = TestProvider.new
-    OpenFeature::Configuration.instance.hooks = [OpenFeature::Hook.new, OpenFeature::Hook.new]
+    OpenFeature::Configuration.instance.hooks = [TestHook.new, TestHook.new]
     OpenFeature::Configuration.instance.evaluation_context = OpenFeature::EvaluationContext.new
 
     assert_equal("Test Provider", OpenFeature::Configuration.instance.provider_metadata.name)

--- a/test/open_feature/hook_test.rb
+++ b/test/open_feature/hook_test.rb
@@ -1,0 +1,55 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "../support/test_provider"
+require_relative "../support/test_hook"
+
+class HookTest < Minitest::Test
+  # See Requirement 4.3.4
+  def test_single_before_hook_is_called_and_updates_evaluation_context
+    hook = TestHook.new mock: Minitest::Mock.new
+    hook_context = OpenFeature::HookContext.new(flag_key: "",
+                                                flag_type: "",
+                                                evaluation_context: OpenFeature::EvaluationContext.new(
+                                                  targeting_key: nil,
+                                                  fields: { "k1" => "v1" }
+                                                ),
+                                                default_value: "")
+
+    hook_return_context = OpenFeature::EvaluationContext.new(targeting_key: "foo",
+                                                             fields:
+                                                               { "k2" => "v2" })
+    hook.mock.expect(:call, hook_return_context, [[hook_context, {}]])
+    result = OpenFeature::Hook::BeforeHook.call(hooks: [hook], context: hook_context, hints: {})
+
+    assert_equal(result, hook_context.evaluation_context.merge(hook_return_context))
+  end
+
+  # See requirement 4.3.3, 4.3.4
+  #
+  # rubocop: disable Metrics/AbcSize
+  def test_multiple_before_hook_works
+    hooks = (0..5).map { |_| TestHook.new mock: Minitest::Mock.new }
+
+    initial_hook_context = OpenFeature::HookContext.new(flag_key: "", flag_type: "",
+                                                        evaluation_context: OpenFeature::EvaluationContext.new(
+                                                          targeting_key: "-1"
+                                                        ),
+                                                        default_value: "")
+
+    hooks.each_with_index.map do |hook, index|
+      last_context = OpenFeature::HookContext.new(flag_key: initial_hook_context.flag_key,
+                                                  flag_type: initial_hook_context.flag_type,
+                                                  evaluation_context: OpenFeature::EvaluationContext.new(
+                                                    targeting_key: (index - 1).to_s
+                                                  ),
+                                                  default_value: initial_hook_context.default_value)
+      hook.mock.expect(:call, OpenFeature::EvaluationContext.new(targeting_key: index.to_s), [[last_context, {}]])
+    end
+
+    result = OpenFeature::Hook::BeforeHook.call(hooks: hooks, context: initial_hook_context, hints: {})
+
+    assert_equal(result, OpenFeature::EvaluationContext.new(targeting_key: (hooks.length - 1).to_s))
+  end
+  # rubocop: enable Metrics/AbcSize
+end

--- a/test/open_feature/hook_test.rb
+++ b/test/open_feature/hook_test.rb
@@ -25,6 +25,24 @@ class HookTest < Minitest::Test
     assert_equal(result, hook_context.evaluation_context.merge(hook_return_context))
   end
 
+  # See https://openfeature.dev/specification/sections/hooks#42-hook-hints
+  # TODO: Answer what hook hints are for?
+  def test_single_hook_is_called_with_hook_hints
+    hook = TestHook.new mock: Minitest::Mock.new
+    hook_context = OpenFeature::HookContext.new(flag_key: "",
+                                                flag_type: "",
+                                                evaluation_context: OpenFeature::EvaluationContext.new(
+                                                  targeting_key: nil
+                                                ),
+                                                default_value: "")
+
+    hook_return_context = OpenFeature::EvaluationContext.new(targeting_key: nil)
+    hints = { "xhint" => "yvalue" }
+    hook.mock.expect(:call, hook_return_context, [[hook_context, hints]])
+    OpenFeature::Hook::BeforeHook.call(hooks: [hook], context: hook_context, hints: hints)
+    hook.mock.verify
+  end
+
   # See requirement 4.3.3, 4.3.4
   #
   # rubocop: disable Metrics/AbcSize

--- a/test/open_feature_test.rb
+++ b/test/open_feature_test.rb
@@ -3,6 +3,7 @@
 
 require "test_helper"
 require_relative "support/test_provider"
+require_relative "support/test_hook"
 
 class OpenFeatureTest < Minitest::Test
   def teardown
@@ -26,8 +27,8 @@ class OpenFeatureTest < Minitest::Test
   end
 
   def test_hooks_can_be_added
-    OpenFeature.add_hooks(OpenFeature::Hook.new)
-    OpenFeature.add_hooks([OpenFeature::Hook.new, OpenFeature::Hook.new])
+    OpenFeature.add_hooks(TestHook.new)
+    OpenFeature.add_hooks([TestHook.new, TestHook.new])
 
     assert_equal(3, OpenFeature::Configuration.instance.hooks.size)
   end
@@ -44,7 +45,7 @@ class OpenFeatureTest < Minitest::Test
     client = OpenFeature.create_client(
       name: "test_client",
       evaluation_context: OpenFeature::EvaluationContext.new,
-      hooks: OpenFeature::Hook.new
+      hooks: TestHook.new
     )
 
     assert_equal("test_client", client.client_metadata.name)

--- a/test/support/test_hook.rb
+++ b/test/support/test_hook.rb
@@ -1,0 +1,20 @@
+# typed: false
+# frozen_string_literal: true
+
+require "open_feature"
+
+class TestHook < OpenFeature::Hook::BeforeHook
+  extend T::Sig
+
+  # rubocop: disable Lint/MissingSuper
+  def initialize(mock: nil)
+    @mock = mock
+  end
+  # rubocop:enable Lint/MissingSuper
+
+  def call(context:, hints:)
+    mock ? mock.call([context, hints]) : OpenFeature::EvaluationContext.new(targeting_key: nil)
+  end
+
+  attr_reader :mock
+end

--- a/test/support/test_provider.rb
+++ b/test/support/test_provider.rb
@@ -17,7 +17,7 @@ class TestProvider
   end
 
   def hooks
-    [OpenFeature::Hook.new]
+    [TestHook.new]
   end
 
   def resolve_boolean_value(**_)


### PR DESCRIPTION
This introduces support for before hooks as per specification. I deliberately left out hints as it is pretty complex already. 

What is deliberately left out:
1) Passing "hook hints" all the way through properly
2) There are some conditions that are not tested, although they are mostly trivial (e.g. sequencing of hooks)
3) The other types of hooks. These other ones should be pretty easy to add in a follow-up: we just create more sub-types and insert in the right place, and these other types don't have the spec that the evaluation context has to be passed through but instead just side-effect