### PR TITLE
Add shutdown methods and make Provider an abstract class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *Breaking* `OpenFeature::Provider` changed from a module interface to an abstract class to support default method implementations.
+
 ## [0.2.0] - 2023-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `OpenFeature::Provider#shutdown` as an overridable method on `Provider`s that can perform any cleanup work for the given provider. This method has a `void` return type and the default implementation is a no-op.
+- Added `OpenFeature.shutdown` to invoke the current provider's `shutdown` method.
+
 ### Changed
 
 - *Breaking* `OpenFeature::Provider` changed from a module interface to an abstract class to support default method implementations.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The OpenFeature specification defines [Structure as a potential return type](htt
 
 We support global evaluation context (set on the `OpenFeature` module), client evaluation context (set on client instances or during client initialization) and invocation evaluation context (passed in during flag evaluation). In compliance with the specification, the invocation context merges into the client context which merges into the global context. Fields in invocation context take precedence over fields in the client context which take precedence over fields in the global context.
 
-### Provider Interface
+### Provider Abstract Class
 
 By default, this implementation sets the provider to the `OpenFeature::NoOpProvider` which always returns the default value. It's up to the individual teams to define their own providers based on their flag source (in the future, I'll release open-source providers based on various, common vendors).
 
@@ -77,6 +77,16 @@ Thanks to Sorbet abstract classes, it's fairly straightforward to implement a ne
 ```ruby
 class JsonFileFlagProvider < OpenFeature::Provider
   extend T::Sig
+
+  sig { void }
+  def initialize
+    @file = File.open("../my_flags.json")
+  end
+
+  sig { overridable.void }
+  def shutdown
+    @file.close
+  end
 
   sig { override.returns(OpenFeature::ProviderMetadata) }
   def metadata

--- a/README.md
+++ b/README.md
@@ -72,13 +72,11 @@ OpenFeature.set_provider(provider)
 
 #### Implementing Custom Providers
 
-Thanks to Sorbet interfaces, it's fairly straightforward to implement a new provider. Here is an example for a JSON-based flag format on disk:
+Thanks to Sorbet abstract classes, it's fairly straightforward to implement a new provider. Here is an example for a JSON-based flag format on disk:
 
 ```ruby
-class JsonFileFlagProvider
+class JsonFileFlagProvider < OpenFeature::Provider
   extend T::Sig
-
-  include OpenFeature::Provider
 
   sig { override.returns(OpenFeature::ProviderMetadata) }
   def metadata
@@ -113,7 +111,7 @@ class JsonFileFlagProvider
 end
 ```
 
-By including the `OpenFeature::Provider` module, Sorbet will indicate what methods it's expecting and what their type signatures should be.
+By inheriting from the `OpenFeature::Provider` class, Sorbet will indicate what methods it's expecting and what their type signatures should be.
 
 ## Development
 

--- a/lib/open_feature.rb
+++ b/lib/open_feature.rb
@@ -48,6 +48,11 @@ module OpenFeature
       )
     end
 
+    sig { void }
+    def shutdown
+      configuration.provider.shutdown
+    end
+
     sig { returns(Configuration) }
     def configuration
       Configuration.instance

--- a/lib/open_feature/multiple_source_provider.rb
+++ b/lib/open_feature/multiple_source_provider.rb
@@ -7,14 +7,13 @@ module OpenFeature
   # The providers will be evaluated in that order and the first
   # non-error result will be used. If all sources return an error
   # then the default value is used.
-  class MultipleSourceProvider
+  class MultipleSourceProvider < Provider
     extend T::Sig
-
-    include Provider
 
     sig { params(providers: T::Array[Provider]).void }
     def initialize(providers:)
       @providers = providers
+      super()
     end
 
     sig { override.returns(ProviderMetadata) }

--- a/lib/open_feature/multiple_source_provider.rb
+++ b/lib/open_feature/multiple_source_provider.rb
@@ -26,6 +26,11 @@ module OpenFeature
       providers.flat_map(&:hooks)
     end
 
+    sig { override.void }
+    def shutdown
+      providers.each(&:shutdown)
+    end
+
     sig do
       override
         .params(

--- a/lib/open_feature/no_op_provider.rb
+++ b/lib/open_feature/no_op_provider.rb
@@ -5,10 +5,8 @@ module OpenFeature
   # Default provider when initializing OpenFeature.
   # Always returns the default value given.
   # This will result in a TypeError if the given default value does not have the correct type.
-  class NoOpProvider
+  class NoOpProvider < Provider
     extend T::Sig
-
-    include Provider
 
     sig { override.returns(ProviderMetadata) }
     attr_reader :metadata
@@ -20,6 +18,7 @@ module OpenFeature
     def initialize
       @metadata = T.let(ProviderMetadata.new(name: "No Op Provider"), ProviderMetadata)
       @hooks = T.let([], T::Array[Hook])
+      super()
     end
 
     sig do

--- a/lib/open_feature/provider.rb
+++ b/lib/open_feature/provider.rb
@@ -3,10 +3,10 @@
 
 module OpenFeature
   # Interface that providers must implement.
-  module Provider
+  class Provider
     extend T::Sig
     extend T::Helpers
-    interface!
+    abstract!
 
     sig { abstract.returns(ProviderMetadata) }
     def metadata; end

--- a/lib/open_feature/provider.rb
+++ b/lib/open_feature/provider.rb
@@ -14,6 +14,9 @@ module OpenFeature
     sig { abstract.returns(T::Array[Hook]) }
     def hooks; end
 
+    sig { overridable.void }
+    def shutdown; end
+
     sig do
       abstract
         .params(

--- a/test/open_feature/client_test.rb
+++ b/test/open_feature/client_test.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../support/test_provider"
-require_relative "../support/test_hook"
 
 class ClientTest < Minitest::Test
   def setup

--- a/test/open_feature/configuration_test.rb
+++ b/test/open_feature/configuration_test.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../support/test_provider"
-require_relative "../support/test_hook"
 
 class ConfigurationTest < Minitest::Test
   def teardown

--- a/test/open_feature/hook_test.rb
+++ b/test/open_feature/hook_test.rb
@@ -1,9 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require_relative "../support/test_provider"
-require_relative "../support/test_hook"
-
 class HookTest < Minitest::Test
   # See Requirement 4.3.4
   def test_single_before_hook_is_called_and_updates_evaluation_context

--- a/test/open_feature/multiple_source_provider_test.rb
+++ b/test/open_feature/multiple_source_provider_test.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../support/test_provider"
 
 class MultipleSourceProviderTest < Minitest::Test
   def setup

--- a/test/open_feature/multiple_source_provider_test.rb
+++ b/test/open_feature/multiple_source_provider_test.rb
@@ -39,6 +39,21 @@ class MultipleSourceProviderTest < Minitest::Test
     assert_equal(1, @first_provider_returns.hooks.size)
   end
 
+  def test_shutdown_can_be_called
+    Counter.instance.intialize
+
+    OpenFeature::MultipleSourceProvider.new(
+      providers: [
+        TestProvider.new(counter: Counter.instance),
+        TestProvider.new(counter: Counter.instance)
+      ]
+    ).shutdown
+
+    assert_equal(2, Counter.instance.shutdown_calls)
+
+    Counter.instance.reset!
+  end
+
   def test_boolean_value_returns_from_first_provider
     expected_details = OpenFeature::ResolutionDetails.new(value: true, reason: "STATIC")
 

--- a/test/open_feature/multiple_source_provider_test.rb
+++ b/test/open_feature/multiple_source_provider_test.rb
@@ -32,7 +32,7 @@ class MultipleSourceProviderTest < Minitest::Test
     )
   end
 
-  def test_metadata_combins_all_providers
+  def test_metadata_combines_all_providers
     assert_equal("Multiple Sources: Test Provider, No Op Provider", @first_provider_returns.metadata.name)
   end
 

--- a/test/open_feature_test.rb
+++ b/test/open_feature_test.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "support/test_provider"
-require_relative "support/test_hook"
 
 class OpenFeatureTest < Minitest::Test
   def teardown

--- a/test/open_feature_test.rb
+++ b/test/open_feature_test.rb
@@ -18,6 +18,17 @@ class OpenFeatureTest < Minitest::Test
     assert_equal("Test Provider", OpenFeature.provider_metadata.name)
   end
 
+  def test_shutdown_calls_provider_shutdown
+    Counter.instance.intialize
+    OpenFeature.set_provider(TestProvider.new(counter: Counter.instance))
+
+    OpenFeature.shutdown
+
+    assert_equal(1, Counter.instance.shutdown_calls)
+
+    Counter.instance.reset!
+  end
+
   def test_evaluation_context_can_be_set
     OpenFeature.set_evaluation_context(OpenFeature::EvaluationContext.new)
 

--- a/test/support/counter.rb
+++ b/test/support/counter.rb
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+require "singleton"
+
+class Counter
+  include Singleton
+
+  attr_accessor :shutdown_calls
+
+  def intialize(shutdown_calls = 0)
+    @shutdown_calls = shutdown_calls
+  end
+
+  def reset!
+    @shutdown_calls = 0
+  end
+end

--- a/test/support/test_provider.rb
+++ b/test/support/test_provider.rb
@@ -3,13 +3,12 @@
 
 require "open_feature"
 
-class TestProvider
-  include OpenFeature::Provider
-
+class TestProvider < OpenFeature::Provider
   def initialize(raising: false, erroring: false, number_value: 2.4)
     @raising = raising
     @erroring = erroring
     @number_value = number_value
+    super()
   end
 
   def metadata

--- a/test/support/test_provider.rb
+++ b/test/support/test_provider.rb
@@ -4,10 +4,13 @@
 require "open_feature"
 
 class TestProvider < OpenFeature::Provider
-  def initialize(raising: false, erroring: false, number_value: 2.4)
+  attr_reader :counter
+
+  def initialize(raising: false, erroring: false, number_value: 2.4, counter: nil)
     @raising = raising
     @erroring = erroring
     @number_value = number_value
+    @counter = counter
     super()
   end
 
@@ -17,6 +20,10 @@ class TestProvider < OpenFeature::Provider
 
   def hooks
     [TestHook.new]
+  end
+
+  def shutdown
+    @counter.shutdown_calls += 1
   end
 
   def resolve_boolean_value(**_)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,5 @@
 require "minitest/autorun"
 require "debug"
 require "open_feature"
+
+Dir["#{__dir__}/support/**/*.rb"].sort.each { |file| require file }


### PR DESCRIPTION
* Update `Provider` to an abstract class to allow for default implementations
* Implement `shutdown` method on [Providers](https://openfeature.dev/specification/sections/providers#25-shutdown)
* Implement `shutdown` method on the [top-level API](https://openfeature.dev/specification/sections/flag-evaluation#16-shutdown)

Partially implement #7 