### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-01-24
+
 ### Added
 
 - Added `OpenFeature::Provider#status` reader that returns an `OpenFeature::ProviderStatus`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openfeature-sdk-sorbet (0.2.0)
+    openfeature-sdk-sorbet (0.3.0)
       sorbet-runtime (~> 0.5)
       sorbet-struct-comparable (~> 1.3)
       zeitwerk (~> 2.6)

--- a/openfeature-sdk-sorbet.gemspec
+++ b/openfeature-sdk-sorbet.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "openfeature-sdk-sorbet"
-  spec.version = "0.2.0"
+  spec.version = "0.3.0"
   spec.authors = ["Max VelDink"]
   spec.email = ["maxveldink@gmail.com"]
 


### PR DESCRIPTION
## [0.3.0] - 2024-01-24

### Added

- Added `OpenFeature::Provider#status` reader that returns an `OpenFeature::ProviderStatus`.
- Added `OpenFeature::Provider#init` as an overridable method on `Provider`s that can perform any initialization work for the given provider. This method accepts the global `EvaluationContext` and has a `void` return type. The default implementation is a no-op.
- Added `OpenFeature::Provider#shutdown` as an overridable method on `Provider`s that can perform any cleanup work for the given provider. This method has a `void` return type and the default implementation is a no-op.
- Added `OpenFeature.shutdown` to invoke the current provider's `shutdown` method.

### Changed

- *Breaking* Changed minimum supported Ruby version to 3.1.
- *Breaking* `OpenFeature::Provider` changed from a module interface to an abstract class to support default method implementations.
- *Breaking* `OpenFeature::Provider.initialize` now must accept an `OpenFeature::ProviderStatus`. Any providers may pass this in during initialization. If you need to do additional setup in `Provider.init`, we recommend you pass `OpenFeature::ProviderStatus::NotReady` here.